### PR TITLE
[Build Failing] GLAD missing `glad_glStringi` symbol

### DIFF
--- a/lib/gl2/include/glad/glad.h
+++ b/lib/gl2/include/glad/glad.h
@@ -1179,6 +1179,12 @@ GLAPI PFNGLGETINTEGERVPROC glad_glGetIntegerv;
 typedef const GLubyte * (APIENTRYP PFNGLGETSTRINGPROC)(GLenum name);
 GLAPI PFNGLGETSTRINGPROC glad_glGetString;
 #define glGetString glad_glGetString
+
+typedef const GLubyte * (APIENTRYP PFNGLGETSTRINGIPROC)(GLenum name, GLuint index);
+GLAPI PFNGLGETSTRINGIPROC glad_glGetStringi;
+#define glGetString glad_glGetStringi
+
+
 typedef void (APIENTRYP PFNGLGETTEXIMAGEPROC)(GLenum target, GLint level, GLenum format, GLenum type, void *pixels);
 GLAPI PFNGLGETTEXIMAGEPROC glad_glGetTexImage;
 #define glGetTexImage glad_glGetTexImage

--- a/lib/gl2/src/glad.c
+++ b/lib/gl2/src/glad.c
@@ -432,6 +432,7 @@ PFNGLGETSHADERINFOLOGPROC glad_glGetShaderInfoLog = NULL;
 PFNGLGETSHADERSOURCEPROC glad_glGetShaderSource = NULL;
 PFNGLGETSHADERIVPROC glad_glGetShaderiv = NULL;
 PFNGLGETSTRINGPROC glad_glGetString = NULL;
+PFNGLGETSTRINGIPROC glad_glGetStringi = NULL;
 PFNGLGETTEXENVFVPROC glad_glGetTexEnvfv = NULL;
 PFNGLGETTEXENVIVPROC glad_glGetTexEnviv = NULL;
 PFNGLGETTEXGENDVPROC glad_glGetTexGendv = NULL;
@@ -852,6 +853,7 @@ static void load_GL_VERSION_1_0(GLADloadproc load) {
 	glad_glGetFloatv = (PFNGLGETFLOATVPROC)load("glGetFloatv");
 	glad_glGetIntegerv = (PFNGLGETINTEGERVPROC)load("glGetIntegerv");
 	glad_glGetString = (PFNGLGETSTRINGPROC)load("glGetString");
+	glad_glGetStringi = (PFNGLGETSTRINGIPROC)load("glGetStringi");
 	glad_glGetTexImage = (PFNGLGETTEXIMAGEPROC)load("glGetTexImage");
 	glad_glGetTexParameterfv = (PFNGLGETTEXPARAMETERFVPROC)load("glGetTexParameterfv");
 	glad_glGetTexParameteriv = (PFNGLGETTEXPARAMETERIVPROC)load("glGetTexParameteriv");


### PR DESCRIPTION
During build process `lld` reported unknown symbol `glad_glStringi`
After quick search, it was apparent that Glad did not reexport this symbol.

Alternative here would be reimporting glad generated files. 
